### PR TITLE
Adding the 3TeV Optics Analysis

### DIFF
--- a/docs/logbook/LHC/2026_lhc.md
+++ b/docs/logbook/LHC/2026_lhc.md
@@ -17,22 +17,25 @@ The tables below can be sorted by clicking next to the column headers.
 | 2026-02-26 13:30 | 2026-02-26 23:30 | 1W 0.25WN | Commissioning | Injection, Ramp and Flattop Validation | [Shift Start](logbook://2026-02-26,1081,4495698) / [Summary](logbook://2026-02-26,1081,4496225) ([OP][op_first_optics_commissioning]{.cern_login target=_blank})  |
 | 2026-02-27 04:50 | 2026-02-27 05:00 |    0WN    |   OP Kicks    |   Kicks from Michi Down the Squeeze    |                                                            [Entry](logbook://2026-02-27,1081,4496528)                                                             |
 | 2026-02-27 13:00 | 2026-02-27 23:59 | 1W 0.5WN  | Commissioning |  Flattop to End of Squeeze Validation  | [Shift Start](logbook://2026-02-27,1081,4496757) / [Summary](logbook://2026-02-27,1081,4497480) ([OP][op_second_optics_commissioning]{.cern_login target=_blank}) |
-| 2026-03-04 01:30 | 2026-03-04 06:00 |  0.70WN   | Commissioning |   1.2TeV Cycle (for LHCb) Validation   | [Shift Start](logbook://2026-03-04,1081,4501759) / [Summary](logbook://2026-03-04,1081,4501955) ([OP][op_1p2Tev_cycle_commissioning]{.cern_login target=_blank})  |
+| 2026-03-04 01:30 | 2026-03-04 06:00 |  0.70WN   | Commissioning |   1.2TeV Cycle (for LHCb) Validation   | [Shift Start](logbook://2026-03-04,1081,4501759) / [Summary](logbook://2026-03-04,1081,4501955) ([OP][op_1p2TeV_cycle_commissioning]{.cern_login target=_blank})  |
 | 2026-03-07 07:00 | 2026-03-07 14:00 |   0.9H    | Commissioning |        VdM Optics Commissioning        |   [Shift Start](logbook://2026-03-07,1081,4505443) / [Summary](logbook://2026-03-07,1081,4505539) ([OP][op_VdM_cycle_commissioning]{.cern_login target=_blank})   |
 | 2026-03-08 10:05 | 2026-03-08 10:15 |    0W     |   OP Kicks    |       Kicks from George at 3TeV        |                                                            [Entry](logbook://2026-03-08,1081,4506212)                                                             |
-
+| 2026-03-10 16:45 | 2026-03-10 17:15 |  0.0625W  |   Analysis    |           3TeV Optics Checks           |                                   [Entries](logbook://2026-03-10,1081,4508135) ([OP][op_3TeV_checks]{.cern_login target=_blank})                                   |
 <!--                                                                                                                               Logbook Links: [LINK_NAME](logbook://date, logbook_id, event_id)            -->
 
 <!-- OP logbook links below -->
 [op_first_optics_commissioning]: https://be-op-logbook.web.cern.ch/elogbook-server/GET/showEventInLogbook/4496222
 [op_second_optics_commissioning]: https://be-op-logbook.web.cern.ch/elogbook-server/GET/showEventInLogbook/4497533
-[op_1p2Tev_cycle_commissioning]: https://be-op-logbook.web.cern.ch/elogbook-server/GET/showEventInLogbook/4501951
+[op_1p2TeV_cycle_commissioning]: https://be-op-logbook.web.cern.ch/elogbook-server/GET/showEventInLogbook/4501951
 [op_VdM_cycle_commissioning]: https://be-op-logbook.web.cern.ch/elogbook-server/GET/showEventInLogbook/4505546
+[op_3TeV_checks]: https://be-op-logbook.web.cern.ch/elogbook-server/GET/showEventInLogbook/4508156
+
 <!-- Tooltips -->
 
 *[Injection, Ramp and Flattop Validation]: Optics at injection, in the ramp and at flat top (1.2m) all good and similar to last year's measurements (end of commissioning and ramp-squeeze-rotate MD). Energy measurement showed a small offset for B1 at injection, B2 was limited by kick amplitude. A coupling correction (feed-forward) was integrated at 1.8TeV. Had a failure of arc12 sextupoles affecting B2 measurements and forced a dump.
 *[Flattop to End of Squeeze Validation]: Had a preview from Michi's kicks in the night. Optics consistent with 2025 down to 60/60cm. Noticed a degradation starting at 60/30cm, especially in B2, but not requiring new corrections. Worsened at 60/18cm. Determined trim of Q5R5 was found to be an efficient correction. It is trimmed at 0 at 60/24cm down to 1 at 60/18cm and constant onwards. MKD-TCT phase advances checked and within tolerances. Kmod showed lumi imbalance of 2% in favor of CMS, dumped before we could check the waist knob. After discussions it was chosen to leave things this way.
 *[1.2TeV Cycle (for LHCb) Validation]: Measured on-momentum at injection and two match points in the ramp; on-off momentum at flattop (10m) and at the end of squeeze (3.1m). All good for both beams: beta-beating below 10% with a few points up to 15%. No constraint on MKD-TCT phase advance, no corrections needed. Did two K-modulations for IP8 and we have around 3% betastar-beating, with max 6% in one plane. Note that chroma drifted a lot.
 *[VdM Optics Commissioning]: Commissioned VdM optics at 50m and 24m betastar. Optics very consistent w.r.t 2025, coupling corrections computed and applied (incl. arc-by-arc, see logbook for knobs). K-modulation for IP1/5 showed good betastar, less than 10% deviation and similar to last year.
+*[3TeV Optics Checks]: Checked the 3TeV optics after George's kicks. Both beams nicely below 10% beta-beating, dispersion fine.
 
 --8<-- "docs/logbook/footer_shifts"

--- a/docs/logbook/LHC/2026_lhc.md
+++ b/docs/logbook/LHC/2026_lhc.md
@@ -20,7 +20,7 @@ The tables below can be sorted by clicking next to the column headers.
 | 2026-03-04 01:30 | 2026-03-04 06:00 |  0.70WN   | Commissioning |   1.2TeV Cycle (for LHCb) Validation   | [Shift Start](logbook://2026-03-04,1081,4501759) / [Summary](logbook://2026-03-04,1081,4501955) ([OP][op_1p2TeV_cycle_commissioning]{.cern_login target=_blank})  |
 | 2026-03-07 07:00 | 2026-03-07 14:00 |   0.9H    | Commissioning |        VdM Optics Commissioning        |   [Shift Start](logbook://2026-03-07,1081,4505443) / [Summary](logbook://2026-03-07,1081,4505539) ([OP][op_VdM_cycle_commissioning]{.cern_login target=_blank})   |
 | 2026-03-08 10:05 | 2026-03-08 10:15 |    0W     |   OP Kicks    |       Kicks from George at 3TeV        |                                                            [Entry](logbook://2026-03-08,1081,4506212)                                                             |
-| 2026-03-10 16:45 | 2026-03-10 17:15 |  0.0625W  |   Analysis    |           3TeV Optics Checks           |                                   [Entries](logbook://2026-03-10,1081,4508135) ([OP][op_3TeV_checks]{.cern_login target=_blank})                                   |
+| 2026-03-10 16:45 | 2026-03-10 17:15 |  0.0625W  |   Analysis    |           3TeV Optics Checks           |                                  [Entries](logbook://2026-03-10,1081,4508135) ([OP][op_3TeV_checks]{.cern_login target=_blank})                                   |
 <!--                                                                                                                               Logbook Links: [LINK_NAME](logbook://date, logbook_id, event_id)            -->
 
 <!-- OP logbook links below -->


### PR DESCRIPTION
Logbook entry for the analysis of the 3TeV optics we were asked to do on Tuesday. This is from the kicks taken by George (who had a lot of fun, 60% kicks!) two days before.

No summary as it is just two straightforward analyses. One link to the OMC logbook, one link to the entry in the OP logbook.