### PR TITLE
Temporarilly point to AmpDet Procedure Page

### DIFF
--- a/docs/guis/betabeat/ampdet.md
+++ b/docs/guis/betabeat/ampdet.md
@@ -1,4 +1,5 @@
 # Amplitude Detuning Analysis
 
 !!! warning "Incomplete"
-    This page is a placeholder and is not yet complete.
+    This page is a placeholder and is yet to be written.
+    For now, please refer to the analysis section of the [Amplitude Detuning procedure page](../../measurements/procedures/ampdet.md#analysis), which includes steps and screenshots.


### PR DESCRIPTION
It is unlikely I will have time to write the Amplitude Detuning page of the BBGUI pages before I leave, considering there are more important pages to be written.

Thankfully, there is already a step by step analysis guide in the AmpDet procedure page, quite thoroughly written by Joschua some time back.

For the time being, I am making sure the BBGUI AmpDet pages points users to that guide page.